### PR TITLE
[remove] ecdhCurve option from tls.connect for https links

### DIFF
--- a/lib/icystream.js
+++ b/lib/icystream.js
@@ -51,7 +51,7 @@ function getStreamStation(url, callback) {
     var client = tls.connect(
       port,
       url.hostname,
-      { ecdhCurve: false, servername: url.hostname },
+      { servername: url.hostname },
       function () {
         client.write(getString);
       }


### PR DESCRIPTION
Fixes ``The "options.ecdhCurve" property must be of type string. Received type boolean (false)`` when using https urls

May solve issue #21

Node version: v15.7.0
Radio tested: icecast (azuracast)